### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: erlang
+otp_release:
+   - 17.0
+   - R16B03-1
+   - R16B03
+   - R16B02
+   - R16B01
+   - R15B03
+   - R15B02
+   - R15B01
+   - R14B04
+   - R14B03
+   - R14B02
+script: "make all test doc"


### PR DESCRIPTION
It seems to work on all the OTP versions added to the file:
https://travis-ci.org/lastres/elarm/builds/26932229
