### PR TITLE
Update additional info when an alarm is repeated

### DIFF
--- a/src/elarm_alarmlist.erl
+++ b/src/elarm_alarmlist.erl
@@ -62,7 +62,14 @@ new_alarm(#alarm{ alarm_id = AlId, src = Src, event_id = EventId } = Alarm,
     {ok, State}.
 
 -spec repeat_alarm(alarm(), #al_state{}) -> {ok, #al_state{}} | {error, term()}.
-repeat_alarm(_Alarm, State) ->
+repeat_alarm(#alarm{ alarm_id = AlId,
+                     src = Src,
+                     additional_information = AddInfo },
+          #al_state{ alarmlist = AList } = State) ->
+    Key = {AlId, Src},
+    [{Key, OldAlarm}] = ets:lookup(AList, Key),
+    NewAlarm = OldAlarm#alarm{ additional_information = AddInfo },
+    true = ets:insert(AList, {Key, NewAlarm}),
     {ok, State}.
 
 -spec acknowledge(alarm_id(), alarm_src(), ack_info(), #al_state{}) ->


### PR DESCRIPTION
Previously, when an alarm was repeated, the additional info wasn't changed in the alarm:

    > elarm:raise(myalarm, mysrc, info_1).
    > elarm:get_alarms().
    ... info_1 ...
    > elarm:raise(myalarm, mysrc, info_2).
    > elarm:get_alarms().
    ... info_1 ...  # Still info_1

Now it is changed:

    > elarm:raise(myalarm, mysrc, info_1).
    > elarm:get_alarms().
    ... info_1 ...
    > elarm:raise(myalarm, mysrc, info_2).
    > elarm:get_alarms().
    ... info_2 ...  # Now it's info_2

Note: IIRC, this change won't affect WombatOAM, because that has a custom alarmlist callback module that is uses instead of `elarm_alarmlist`.